### PR TITLE
Only allow class names once

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@
   var whitespace = /[\n\r\s]/g;
   var indent = '  ';
   var messagePrefix = 'ReactStyleSheets: ';
+  var headTag = document.getElementsByTagName('head')[0];
 
   var commaSeparatedProperties = [
     'fontFamily'
@@ -78,23 +79,23 @@
     'visited'
   ];
 
-  var headTag = document.getElementsByTagName('head')[0];
-
-  if (!headTag) {
-    throw new Error(
-      messagePrefix + 'Could not locate head tag. Ensure your javascript is included after the closing head tag.'
-    );
-  }
-
-  var styleTag = document.createElement('style');
-  styleTag.setAttribute('type', 'text/css');
-  headTag.appendChild(styleTag);
-
   function warn (message) {
     if (typeof console !== 'undefined' && typeof console.warn === 'function') {
       console.warn(messagePrefix + message);
     }
   }
+
+  function error (message) {
+    throw new Error(messagePrefix + message);
+  }
+
+  if (!headTag) {
+    error('Could not locate head tag. Ensure your javascript is included after the closing head tag.');
+  }
+
+  var styleTag = document.createElement('style');
+  styleTag.setAttribute('type', 'text/css');
+  headTag.appendChild(styleTag);
 
   function toSpinalCase (value) {
     return value.replace(/(^|[a-z])([A-Z])/g, '$1-$2').toLowerCase();
@@ -125,9 +126,7 @@
 
     for (var key in style) {
       if (key.indexOf('-') >= 0) {
-        throw new Error(
-          messagePrefix + 'Found "-" in a style property name. Style property names must be defined in camelcase.'
-        );
+        error('Found "-" in a style property name. Style property names must be defined in camelcase.');
       }
 
       var value = style[key];
@@ -143,7 +142,7 @@
       // Nested styles
       } else if (nestedStyles.indexOf(key) >= 0) {
         if (typeof value !== 'object') {
-          throw new Error(messagePrefix + 'Nested styles such as hover must be an object.');
+          error('Nested styles such as hover must be an object.');
         }
 
         var colon = doubleColonStyles.indexOf(key) >= 0 ? '::' : ':';
@@ -185,7 +184,7 @@
     }
 
     if (existingClassNames.indexOf(className) >= 0) {
-      throw new Error(messagePrefix + 'The class name "' + className + '" is already in use, please choose another.');
+      error('The class name "' + className + '" is already in use, please choose another.');
     }
 
     return className;
@@ -202,16 +201,13 @@
       }
 
       if (typeof options !== 'object') {
-        throw new Error(messagePrefix + 'Options must be an object.');
+        error('Options must be an object.');
       }
 
       if (typeof options.vendorPrefixes !== 'undefined') {
         if (typeof options.vendorPrefixes !== 'object' || Array.isArray(options.vendorPrefixes)) {
-          throw new Error(
-            messagePrefix +
-            'vendorPrefixes must be an object with style property names as keys, ' +
-            'and arrays of prefixes as values.'
-          );
+          error('vendorPrefixes must be an object with style property names as keys, ' +
+            'and arrays of prefixes as values.');
         } else {
           vendorPrefixes = options.vendorPrefixes;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,7 @@
     }
 
     if (existingClassNames.indexOf(className) >= 0) {
-      throw new Error('The class name "' + className + '" is already in use, please choose another.');
+      throw new Error(messagePrefix + 'The class name "' + className + '" is already in use, please choose another.');
     }
 
     return className;

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,13 +174,21 @@
   }
 
   function generateUniqueName (className) {
-    var obfuscatedClassName = className + '_' + generateRandomString(5);
+    if (obfuscate) {
+      var obfuscatedClassName = className + '_' + generateRandomString(5);
 
-    while (existingClassNames.indexOf(obfuscatedClassName) >= 0) {
-      obfuscatedClassName = className + '_' + generateRandomString(5);
+      while (existingClassNames.indexOf(obfuscatedClassName) >= 0) {
+        obfuscatedClassName = className + '_' + generateRandomString(5);
+      }
+
+      return obfuscatedClassName;
     }
 
-    return obfuscatedClassName;
+    if (existingClassNames.indexOf(className) >= 0) {
+      throw new Error('The class name "' + className + '" is already in use, please choose another.');
+    }
+
+    return className;
   }
 
   function removeWhitespace (value) {
@@ -232,7 +240,7 @@
       var concat = '';
 
       for (var className in styles) {
-        var obfuscatedClassName = obfuscate ? generateUniqueName(className) : className;
+        var obfuscatedClassName = generateUniqueName(className);
 
         concat += createStyles('.' + className, styles[obfuscatedClassName]);
 
@@ -250,7 +258,7 @@
       var concat = '';
 
       for (var className in styles) {
-        var obfuscatedClassName = obfuscate ? generateUniqueName(className) : className;
+        var obfuscatedClassName = generateUniqueName(className);
 
         concat += createStyles('.' + obfuscatedClassName, styles[className]);
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,8 +9,14 @@
   var stub = sinon.stub;
 
   var ReactStyleSheets;
-  var warnStub = stub(console, 'warn');
   var anError = /^ReactStyleSheets:\s.*/;
+
+  var warnOriginal = console.warn;
+  var warnStub = stub(console, 'warn', function (message) {
+    if (!anError.test(message)) {
+      warnOriginal(message);
+    }
+  });
 
   // Head tags mock
   var headTags = [

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,11 +9,11 @@
   var stub = sinon.stub;
 
   var ReactStyleSheets;
-  var anError = /^ReactStyleSheets:\s.*/;
+  var aReactStyleSheetsError = /^ReactStyleSheets:\s.*/;
 
   var warnOriginal = console.warn;
   var warnStub = stub(console, 'warn', function (message) {
-    if (!anError.test(message)) {
+    if (!aReactStyleSheetsError.test(message)) {
       warnOriginal(message);
     }
   });
@@ -108,9 +108,9 @@
     });
 
     it('should error if invalid options are provided', function () {
-      expect(ReactStyleSheets.setOptions).to.throw(anError);
-      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: 'nope'})).to.throw(anError);
-      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: []})).to.throw(anError);
+      expect(ReactStyleSheets.setOptions).to.throw(aReactStyleSheetsError);
+      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: 'nope'})).to.throw(aReactStyleSheetsError);
+      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: []})).to.throw(aReactStyleSheetsError);
     });
 
     it('should error if the same class name is defined twice when not obfuscating', function () {
@@ -126,7 +126,7 @@
 
       ReactStyleSheets.createUniqueClassStyles(styles);
 
-      expect(ReactStyleSheets.createUniqueClassStyles.bind(null, styles)).to.throw(anError);
+      expect(ReactStyleSheets.createUniqueClassStyles.bind(null, styles)).to.throw(aReactStyleSheetsError);
 
       ReactStyleSheets.setOptions({
         obfuscate: true

--- a/tests/index.js
+++ b/tests/index.js
@@ -99,6 +99,14 @@
       warnStub.restore();
     });
 
+    it('should error if invalid options are provided', function () {
+      var anError = /^ReactStyleSheets:\s.*/;
+
+      expect(ReactStyleSheets.setOptions).to.throw(anError);
+      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: 'nope'})).to.throw(anError);
+      expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: []})).to.throw(anError);
+    });
+
     it('should create tag styles & add them to the style tag', function () {
       var expected = [
         '',

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,7 +9,7 @@
   var stub = sinon.stub;
 
   var ReactStyleSheets;
-
+  var warnStub = stub(console, 'warn');
   var anError = /^ReactStyleSheets:\s.*/;
 
   // Head tags mock
@@ -69,6 +69,10 @@
       styleTag.innerHTML = '';
     });
 
+    afterEach(function () {
+      warnStub.reset();
+    });
+
     it('should create a style tag and append it to the head tag', function () {
       var getElementsByTagNameSpy = spy(document, 'getElementsByTagName');
       var createElementSpy = spy(document, 'createElement');
@@ -84,8 +88,6 @@
     });
 
     it('should warn if options are set twice', function () {
-      var warnStub = stub(console, 'warn');
-
       ReactStyleSheets.setOptions({
         obfuscate: true
       });
@@ -97,8 +99,6 @@
       });
 
       expect(warnStub).to.have.been.calledOnce;
-
-      warnStub.restore();
     });
 
     it('should error if invalid options are provided', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -420,6 +420,40 @@
       expectLinesToMatch(styleTag.innerHTML, expected);
     });
 
+    it('should minify the created styles if minify is set to true', function () {
+      var expectedNotMinified = [
+        '',
+        'p {',
+        '  color: red;',
+        '}',
+        ''
+      ];
+
+      var expectedMinified = 'p{color:red;}';
+
+      var styles = {
+        p: {
+          color: 'red'
+        }
+      };
+
+      ReactStyleSheets.setOptions({
+        minify: false
+      });
+
+      ReactStyleSheets.createGlobalTagStyles(styles);
+      expectLinesToMatch(styleTag.innerHTML, expectedNotMinified);
+
+      styleTag.innerHTML = '';
+
+      ReactStyleSheets.setOptions({
+        minify: true
+      });
+
+      ReactStyleSheets.createGlobalTagStyles(styles);
+      expect(styleTag.innerHTML).to.equal(expectedMinified);
+    });
+
   });
 
 })();

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,8 @@
 
   var ReactStyleSheets;
 
+  var anError = /^ReactStyleSheets:\s.*/;
+
   // Head tags mock
   var headTags = [
     {
@@ -100,11 +102,29 @@
     });
 
     it('should error if invalid options are provided', function () {
-      var anError = /^ReactStyleSheets:\s.*/;
-
       expect(ReactStyleSheets.setOptions).to.throw(anError);
       expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: 'nope'})).to.throw(anError);
       expect(ReactStyleSheets.setOptions.bind(null, {vendorPrefixes: []})).to.throw(anError);
+    });
+
+    it('should error if the same class name is defined twice when not obfuscating', function () {
+      ReactStyleSheets.setOptions({
+        obfuscate: false
+      });
+
+      var styles = {
+        myClass: {
+          color: 'red'
+        }
+      };
+
+      ReactStyleSheets.createUniqueClassStyles(styles);
+
+      expect(ReactStyleSheets.createUniqueClassStyles.bind(null, styles)).to.throw(anError);
+
+      ReactStyleSheets.setOptions({
+        obfuscate: true
+      });
     });
 
     it('should create tag styles & add them to the style tag', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,6 +6,7 @@
   var sinon = require('sinon');
   var expect = chai.expect;
   var spy = sinon.spy;
+  var stub = sinon.stub;
 
   var ReactStyleSheets;
 
@@ -78,6 +79,24 @@
       expect(createElementSpy).to.have.been.calledWith('style');
       expect(setAttributeSpy).to.have.been.calledWith('type', 'text/css');
       expect(appendChildSpy).to.have.been.calledWith(styleTag);
+    });
+
+    it('should warn if options are set twice', function () {
+      var warnStub = stub(console, 'warn');
+
+      ReactStyleSheets.setOptions({
+        obfuscate: true
+      });
+
+      expect(warnStub).not.to.have.been.called;
+
+      ReactStyleSheets.setOptions({
+        obfuscate: true
+      });
+
+      expect(warnStub).to.have.been.calledOnce;
+
+      warnStub.restore();
     });
 
     it('should create tag styles & add them to the style tag', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,7 +9,7 @@
   var stub = sinon.stub;
 
   var ReactStyleSheets;
-  var aReactStyleSheetsError = /^ReactStyleSheets:\s.*/;
+  var aReactStyleSheetsError = /^ReactStyleSheets:\s.{10,}/;
 
   var warnOriginal = console.warn;
   var warnStub = stub(console, 'warn', function (message) {


### PR DESCRIPTION
Fixes #1 

* Throw an error if the same class name is defined twice, when not obfuscating
* Use custom error function
* Various tests